### PR TITLE
chore: delete lib dir

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,1 +1,0 @@
-// place files you want to import through the `$lib` alias in this folder.


### PR DESCRIPTION
Deletes `lib` dir as it has no use
